### PR TITLE
[Fix] boiler GUI liquid meter

### DIFF
--- a/src/sfk-steamworks/Boiler/BEBoiler.cs
+++ b/src/sfk-steamworks/Boiler/BEBoiler.cs
@@ -540,7 +540,7 @@ namespace SFK.Steamworks.Boiler
               return;
             }
 
-            int consumed = ((int)Math.Round(1 + InputStackTemp / 500));
+            int consumed = (int)Math.Round(1 + InputStackTemp / 500); // in litres
             int produced = consumed * steamProductionCoefitient; // Need for future to use coefficient
 
 
@@ -554,7 +554,8 @@ namespace SFK.Steamworks.Boiler
               outputStack.StackSize += produced;
             }
 
-            inputSlot.TakeOut(consumed);
+            float inputItemsPerLitre = BlockLiquidContainerBase.GetContainableProps(inputStack).ItemsPerLitre;
+            inputSlot.TakeOut((int)(consumed  * inputItemsPerLitre));
 
             MarkDirty(true);
             Api.World.BlockAccessor.MarkBlockEntityDirty(Pos);

--- a/src/sfk-steamworks/Boiler/BlockBoiler.cs
+++ b/src/sfk-steamworks/Boiler/BlockBoiler.cs
@@ -83,8 +83,9 @@ namespace SFK.Steamworks.Boiler
       {
         if (!slot.Empty && (slot is ItemSlotLiquidOnly || slot is ItemSlotGasOnly))
         {
+          float itemsPerLitre = GetContainableProps(slot.Itemstack).ItemsPerLitre;
           // TODO workaround GetCurrentLitres when use not 1:1 litres-item ratio liquids
-          stb.AppendLine(Lang.Get("{0} litres of {1}", slot.Itemstack.StackSize, GetIncontentString(slot.Itemstack)));
+          stb.AppendLine(Lang.Get("{0} litres of {1}", slot.Itemstack.StackSize / itemsPerLitre, GetIncontentString(slot.Itemstack)));
         }
       }
 

--- a/src/sfk-steamworks/Boiler/GuiDialogBoiler.cs
+++ b/src/sfk-steamworks/Boiler/GuiDialogBoiler.cs
@@ -61,11 +61,11 @@ namespace SFK.Steamworks.Boiler
               .AddDynamicText("", CairoFont.WhiteDetailText().WithOrientation(EnumTextOrientation.Center), fuelSlotBounds.RightCopy(5, 16).WithFixedSize(60, 30), "fueltemp")
 
               .AddInset(inputFullnessMeterBounds.ForkBoundingParent(2, 2, 2, 2), 2)
-              .AddDynamicCustomDraw(inputFullnessMeterBounds, createFullnessMeterDraw(1, 50), "inputBar")
+              .AddDynamicCustomDraw(inputFullnessMeterBounds, CreateFullnessMeterDraw(1, 50), "inputBar")
               .AddDynamicText("", CairoFont.WhiteDetailText().WithOrientation(EnumTextOrientation.Center), inputFullnessMeterBounds.BelowCopy(-10, 5).WithFixedSize(60, 30), "inputtemp")
 
               .AddInset(outputFullnessMeterBounds.ForkBoundingParent(2, 2, 2, 2), 2)
-              .AddDynamicCustomDraw(outputFullnessMeterBounds, createFullnessMeterDraw(2, 100), "outputBar")
+              .AddDynamicCustomDraw(outputFullnessMeterBounds, CreateFullnessMeterDraw(2, 100), "outputBar")
           .EndChildElements()
           .Compose()
       ;
@@ -81,24 +81,22 @@ namespace SFK.Steamworks.Boiler
 
     #region Drawings
 
-    private DrawDelegateWithBounds createFullnessMeterDraw(int slotId, float capacity)
+    private DrawDelegateWithBounds CreateFullnessMeterDraw(int slotId, float capacityLitres)
     {
       return (ctx, surface, currentBounds) =>
       {
         ItemSlot liquidSlot = Inventory[slotId];
         if (liquidSlot.Empty) return;
 
-        BEBoiler beboiler = capi.World.BlockAccessor.GetBlockEntity(BlockEntityPosition) as BEBoiler;
         float itemsPerLitre = 1f;
 
         WaterTightContainableProps props = BlockLiquidContainerBase.GetContainableProps(liquidSlot.Itemstack);
         if (props != null)
         {
           itemsPerLitre = props.ItemsPerLitre;
-          capacity = Math.Max(capacity, props.MaxStackSize);
         }
 
-        float fullnessRelative = liquidSlot.StackSize / itemsPerLitre / capacity;
+        float fullnessRelative = liquidSlot.StackSize / itemsPerLitre / capacityLitres;
 
         double offY = (1 - fullnessRelative) * currentBounds.InnerHeight;
 


### PR DESCRIPTION
## Ticket:
- https://www.notion.so/1-16-5-broke-boiler-GUI-liquid-meter-964a3c73fdbd477c8ffdb96be49709b2

## Result:
- refactored liquid pipes, boiler and water pump to use `itemsPerLitre` for all liquid logic